### PR TITLE
Removing `gcc` package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,10 @@ env:
 
 
 before_install:
+    # Remove homebrew.
     - brew remove --force $(brew list)
+    - brew cleanup -s
+    - rm -rf $(brew --cache)
 
 install:
     - |
@@ -23,7 +26,7 @@ install:
 
       conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build jinja2 anaconda-client
+      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
       
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   url: https://pypi.python.org/packages/source/b/bob.ip.draw/bob.ip.draw-{{ version }}.zip
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not linux]
   script: python -B setup.py install --single-version-externally-managed --record record.txt
 
@@ -20,13 +20,11 @@ requirements:
     - setuptools
     - bob.extension >2.0.4
     - bob.blitz
-    - gcc     # [linux]
 
   run:
     - python
     - bob.extension >2.0.4
     - bob.blitz
-    - libgcc  # [linux]
 
 test:
   commands:


### PR DESCRIPTION
We now have a C++11 capable `gcc` compiler in the docker image. It would be nice if you could do the following to try this.
1. Fork this repo.
2. Create a new branch
3. Remove `gcc` and `libgcc`.
4. Add, commit, push to your fork.
5. Open a PR to remove them.
6. Note in the PR that this issue is fixed by it.

Please ping me when you have done these things.
